### PR TITLE
SLAPI misbehaves and sends non-JSON while claiming it is JSON

### DIFF
--- a/lib/http-requests.js
+++ b/lib/http-requests.js
@@ -54,7 +54,15 @@ var _handleResponse = function(callback) {
         if (res.statusCode >= 400 && res.statusCode < 600 || res.statusCode < 10) {
 
             if (body && res.headers['content-type'] === 'application/json') {
-                var error = JSON.parse(body);
+		var error = {};
+		try
+		{
+                	error = JSON.parse(body);
+		}
+		catch (e)
+		{
+			error = {"message":body}
+		}
                 error.statusCode = res.statusCode;
                 return callback(error, {});
             }
@@ -71,7 +79,16 @@ var _handleResponse = function(callback) {
         }
 
         if (res.headers['content-type'] === 'application/json') {
-            return callback(null, JSON.parse(body));
+	    var result = {}
+	    try
+	    {
+		result = JSON.parse(body)
+	    }
+	    catch (e)
+	    {
+		result = {"message":body}
+	    }
+            return callback(null, result);
         }
 
         return callback(null, body);


### PR DESCRIPTION
Totally not a fault of this library, but I have definitely experienced it many times to where the response headers for an error OR for a regular HTTP REST response from the SLAPI say that it is `application/json` and yet, when Node tries to go and parse it with `JSON.parse(...)`, it fails.  I don't think there's much we can do to try to get the SLAPI to cooperate, so I just added in these try/catch blocks that handle the case where they are claiming it's JSON but actually just sending freeform text.